### PR TITLE
Ensure About is set in front-matter

### DIFF
--- a/.github/ISSUE_TEMPLATE/incident_report_simple.md
+++ b/.github/ISSUE_TEMPLATE/incident_report_simple.md
@@ -1,5 +1,6 @@
 ---
 name: "Orcfax Incident Report"
+about: "Orcfax standard template for issue reporting"
 title: "INCIDENT 0000 - Example Incident"
 published: YYYY-MM-DD
 status: "Under Review"


### PR DESCRIPTION
Fixes the below issue with the template.

![image](https://github.com/user-attachments/assets/da3b2d75-d739-49fa-9811-218a2f86d4fd)
